### PR TITLE
Potential fix for code scanning alert no. 5: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/Code/PL/Web.Debug.config
+++ b/Code/PL/Web.Debug.config
@@ -17,7 +17,7 @@
   
   <system.web>
     <!-- Enable debug mode for development -->
-    <compilation debug="true" xdt:Transform="SetAttributes" />
+    <compilation xdt:Transform="SetAttributes" />
     
     <!-- Development-specific settings -->
     <customErrors mode="Off" xdt:Transform="SetAttributes" />


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/5](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/5)

To address the issue, the `debug="true"` flag in the `<compilation>` element should be removed or set to `false`. This ensures that the configuration file does not inadvertently enable debug mode, which could expose sensitive information or degrade performance. Since the file is named `Web.Debug.config`, it is likely intended for development purposes, but removing the flag entirely is a more robust solution to prevent misuse.

**Steps to fix:**
1. Locate the `<compilation>` element in the `Code/PL/Web.Debug.config` file.
2. Remove the `debug="true"` attribute or set it to `false`.
3. Ensure the change does not affect other development-specific settings in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
