### PR TITLE
Potential fix for code scanning alert no. 7: Missing global error handler

### DIFF
--- a/Code/PL/Web.Debug.config
+++ b/Code/PL/Web.Debug.config
@@ -20,7 +20,7 @@
     <compilation debug="true" xdt:Transform="SetAttributes" />
     
     <!-- Development-specific settings -->
-    <customErrors mode="Off" xdt:Transform="SetAttributes" />
+    <customErrors mode="RemoteOnly" xdt:Transform="SetAttributes" />
   </system.web>
   
   <appSettings>


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/7](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/7)

To fix the issue, we will modify the `customErrors` mode in the `Web.Debug.config` file to `RemoteOnly`. This ensures that detailed error information is only displayed when the application is accessed locally, which is appropriate for debugging during development. Additionally, this change minimizes the risk of sensitive information being exposed if the configuration is accidentally deployed to production.

**Steps to implement the fix:**
1. Locate the `<customErrors>` element in the `Web.Debug.config` file.
2. Change the `mode` attribute from `Off` to `RemoteOnly`.

This change does not require any additional imports, methods, or definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
