### PR TITLE
Potential fix for code scanning alert no. 6: 'requireSSL' attribute is not set to true

### DIFF
--- a/Code/PL/Web.config
+++ b/Code/PL/Web.config
@@ -49,7 +49,7 @@
     </customErrors>
     
     <!-- Security Headers -->
-    <httpCookies httpOnlyCookies="true" requireSSL="false" />
+    <httpCookies httpOnlyCookies="true" requireSSL="true" />
     
     <!-- Request Validation -->
     <pages validateRequest="true" />


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/6](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/6)

To fix the issue, the `requireSSL` attribute in the `<httpCookies>` element should be set to `"true"`. This ensures that cookies are only transmitted over HTTPS, mitigating the risk of interception. The change should be made in the `Web.config` file under the `<system.web>` section. No additional imports or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
