### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe HTML constructed from library input

### DIFF
--- a/Code/ExcelExportWeb/wwwroot/lib/jquery/dist/jquery.js
+++ b/Code/ExcelExportWeb/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement("a");
+		anchor.id = expando;
+		anchor.href = "";
+		anchor.setAttribute("disabled", "disabled");
+		el.appendChild(anchor);
+
+		var select = document.createElement("select");
+		select.id = expando + "-\r\\";
+		select.setAttribute("disabled", "disabled");
+
+		var option = document.createElement("option");
+		option.setAttribute("selected", "");
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/4](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/4)

To fix the issue, we need to ensure that the dynamically constructed HTML is sanitized or escaped to prevent XSS. The best approach is to avoid using `innerHTML` for dynamic content and instead use safer DOM manipulation methods like `createElement` and `appendChild`. Alternatively, if `innerHTML` must be used, the input should be sanitized using a library like `DOMPurify` or escaped to neutralize any malicious content.

In this case, we will replace the use of `innerHTML` with DOM manipulation methods to construct the same HTML structure safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
