### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/Code/ExcelExportWeb/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Code/ExcelExportWeb/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return $( this.currentForm ).find(selector)[ 0 ];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/1](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/1)

To fix the issue, the `clean` method should ensure that the `selector` parameter is treated strictly as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `jQuery(selector)`. The `find` method interprets the input as a CSS selector, preventing the evaluation of HTML and mitigating the risk of XSS.

**Steps to implement the fix:**
1. Replace the `$(selector)[0]` call in the `clean` method with `$(this.currentForm).find(selector)[0]`. This ensures that the `selector` is treated as a CSS selector within the context of the current form.
2. Verify that the change does not affect existing functionality by testing the plugin with various valid selectors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
