### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/Code/ExcelExportWeb/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Code/ExcelExportWeb/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,8 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			var sanitizedElement = this.escapeCssMeta(element);
+			return $( sanitizedElement ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/2](https://github.com/tarunbatta/ExcelExportCSharp/security/code-scanning/2)

To fix the issue, the `validationTargetFor` method should sanitize `element` before using it in the `$(element)` call. This can be achieved by applying the `escapeCssMeta` method to ensure that `element` is treated as a safe CSS selector. Additionally, the plugin should document that `element` must be sanitized if it originates from untrusted sources.

**Steps to fix:**
1. Modify the `validationTargetFor` method to sanitize `element` using `escapeCssMeta`.
2. Ensure that all calls to `$(element)` within the method use the sanitized version of `element`.
3. Add documentation to the plugin to inform users about the importance of sanitizing inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
